### PR TITLE
All query parameters should be URL encoded in these two examples

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -1589,7 +1589,7 @@ sending the following HTTP response:
 
     HTTP/1.1 302 Found
     Location: https://client.example.com/cb?code=SplxlOBeZQQYbYS6WxSbIA
-              &state=xyz&iss=https://authorization-server.example/
+              &state=xyz&iss=https%3A%2F%2Fauthorization-server.example.com
 
 The client MUST ignore unrecognized response parameters.  The
 authorization code string size is left undefined by this
@@ -1710,7 +1710,7 @@ sending the following HTTP response:
 
     HTTP/1.1 302 Found
     Location: https://client.example.com/cb?error=access_denied
-              &state=xyz&iss=https://authorization-server.example/
+              &state=xyz&iss=https%3A%2F%2Fauthorization-server.example.com
 
 ### Token Endpoint Extension {#code-token-extension}
 


### PR DESCRIPTION
I have also included a minor change with the domain, so authorization-server.example becomes to be authorization-server.example.com. 

I believe it's more common to use example.com for documentation purposes, see https://en.wikipedia.org/wiki/Example.com.