### PR TITLE
Move attack introduction to end of the Open Redirector section

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -2961,15 +2961,15 @@ possible) any value received -- in particular, the value of the
 
 ## Open Redirection {#open-redirectors}
 
-The following attacks can occur when an AS or client has an open
-redirector. An open redirector is an endpoint that forwards a
-user's browser to an arbitrary URI obtained from a query parameter.
+An open redirector is an endpoint that forwards a user's browser
+to an arbitrary URI obtained from a query parameter.
 Such endpoints are sometimes implemented, for example, to show a
 message before a user is then redirected to an external website,
 or to redirect users back to a URL they were intending to visit
 before being interrupted, e.g., by a login prompt.
 
-
+The following attacks can occur when an AS or client has an open
+redirector. 
 
 ### Client as Open Redirector {#open_redirector_on_client}
 


### PR DESCRIPTION
Introduce Open Redirector's definition first, then introduce its weakness.