### PR TITLE
clarify expires_in is a JSON number

### DIFF
--- a/draft-ietf-oauth-v2-1.md
+++ b/draft-ietf-oauth-v2-1.md
@@ -1265,7 +1265,8 @@ and an HTTP 200 (OK) status code:
      {{access-tokens}}.  Value is case insensitive.
 
 "expires_in":
-:    RECOMMENDED.  The lifetime in seconds of the access token.  For
+:    RECOMMENDED.  A JSON number that represents the lifetime
+     in seconds of the access token.  For
      example, the value `3600` denotes that the access token will
      expire in one hour from the time the response was generated.
      If omitted, the authorization server SHOULD provide the


### PR DESCRIPTION
This small PR attempts to clarify an unfortunately not that rare mistake of server implementations where they respond with a JSON string and not the expected JSON number.

In between the client implementations I maintain I get a PRs/issues at least twice a year which ask that the clients attempt to normalize the Token Endpoint response expires_in value instead of expecting it to be a number.